### PR TITLE
Add ds config file flag for slim model saving

### DIFF
--- a/configs/ds_config_bf16_save_16bit_weights.json
+++ b/configs/ds_config_bf16_save_16bit_weights.json
@@ -1,0 +1,40 @@
+{
+  "bf16": {
+    "enabled": "auto"
+  },
+  "optimizer": {
+    "type": "AdamW",
+    "params": {
+      "lr": "auto",
+      "betas": "auto",
+      "eps": "auto",
+      "weight_decay": "auto"
+    }
+  },
+  "scheduler": {
+    "type": "WarmupLR",
+    "params": {
+      "warmup_min_lr": "auto",
+      "warmup_max_lr": "auto",
+      "warmup_num_steps": "auto"
+    }
+  },
+  "zero_optimization": {
+    "stage": 3,
+    "overlap_comm": true,
+    "contiguous_gradients": true,
+    "sub_group_size": 1e9,
+    "reduce_bucket_size": "auto",
+    "stage3_prefetch_bucket_size": "auto",
+    "stage3_param_persistence_threshold": "auto",
+    "stage3_max_live_parameters": 1e9,
+    "stage3_max_reuse_distance": 1e9,
+    "stage3_gather_16bit_weights_on_model_save": true
+  },
+  "gradient_accumulation_steps": "auto",
+  "gradient_clipping": "auto",
+  "steps_per_print": 2000,
+  "train_batch_size": "auto",
+  "train_micro_batch_size_per_gpu": "auto",
+  "wall_clock_breakdown": false
+}


### PR DESCRIPTION
I've added this config file which is similar to `ds_flan_t5_z3_config_bf16.json` (so without offload!) but includes the `    "stage3_gather_16bit_weights_on_model_save": true` flag. 

Without that flag set to `True`, `trainer.save_model()` for me saved roughly 80 GB of optimizer state for a 7B param model. As such this is not so bad because it allows to resume training but somehow this also resulted in the training job running for >2 hours **after** training had finished just because it compressed & uploaded those 80 GBs to `s3`.

After setting the flag, the saved model is <10 GB and the upload time is much shorter.

Maybe it's worth it to make this an argument that then dynamically changes the config argument?